### PR TITLE
Include phoenix_pubsub in application dependencies.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule PhoenixPubsubRedis.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :poolboy, :redix, :redix_pubsub]]
+    [applications: [:logger, :poolboy, :redix, :redix_pubsub, :phoenix_pubsub]]
   end
 
   defp deps do


### PR DESCRIPTION
For exrm, application dependencies must be defined. See [here](https://hexdocs.pm/exrm/common-issues.html). This started breaking things somewhere after 2.0.