### PR TITLE
Use Keyword instead of Dict

### DIFF
--- a/lib/phoenix_pubsub_redis/redis_server.ex
+++ b/lib/phoenix_pubsub_redis/redis_server.ex
@@ -13,7 +13,7 @@ defmodule Phoenix.PubSub.RedisServer do
   Starts the server
   """
   def start_link(opts) do
-    GenServer.start_link(__MODULE__, opts, name: Dict.fetch!(opts, :name))
+    GenServer.start_link(__MODULE__, opts, name: Keyword.fetch!(opts, :name))
   end
 
   @doc false

--- a/mix.lock
+++ b/mix.lock
@@ -5,4 +5,4 @@
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []},
   "redix": {:hex, :redix, "0.4.0", "c8cfad755252e5441c4119437ba3a8989518af7aa90dbd6f4ff7207b72e4a967", [:mix], [{:connection, "~> 1.0.0", [hex: :connection, optional: false]}]},
-  "redix_pubsub": {:hex, :redix_pubsub, "0.1.0", "b408913bf2287ed8749b6f2abe8d7cecdcd6cb4dbd9635ecc444c183100bed00", [:mix], [{:redix, "~> 0.4.0", [hex: :redix, optional: false]}, {:connection, "~> 1.0", [hex: :connection, optional: false]}]}}
+  "redix_pubsub": {:hex, :redix_pubsub, "0.1.0", "b408913bf2287ed8749b6f2abe8d7cecdcd6cb4dbd9635ecc444c183100bed00", [:mix], [{:connection, "~> 1.0", [hex: :connection, optional: false]}, {:redix, "~> 0.4.0", [hex: :redix, optional: false]}]}}


### PR DESCRIPTION
This fixes a deprecation warning for using `Dict` - not sure why my lock changed but I'm guessing it's from my run of `mix deps.get` on a newer mix hex, happy to drop that change!