### PR TITLE
Update to redix 0.9

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -18,13 +18,12 @@ defmodule PhoenixPubsubRedis.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :poolboy, :redix, :redix_pubsub, :phoenix_pubsub]]
+    [applications: [:logger, :poolboy, :redix, :phoenix_pubsub]]
   end
 
   defp deps do
     [{:phoenix_pubsub, "~> 1.0"},
-     {:redix, "~> 0.8.1"},
-     {:redix_pubsub, "~> 0.5.0"},
+     {:redix, "~> 0.9.0"},
      {:ex_doc, "~> 0.17.1", only: :docs},
      {:poolboy, "~> 1.5.1 or ~> 1.6"}]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -4,6 +4,5 @@
   "ex_doc": {:hex, :ex_doc, "0.17.1", "39f777415e769992e6732d9589dc5846ea587f01412241f4a774664c746affbb", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.2", "bfa7fd52788b5eaa09cb51ff9fcad1d9edfeb68251add458523f839392f034c1", [:mix], [], "hexpm"},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
-  "redix": {:hex, :redix, "0.8.1", "c708ce37dd8d770bcb7a5df0447da7660233c50869edb0872e0d5ff1988eb271", [:mix], [], "hexpm"},
-  "redix_pubsub": {:hex, :redix_pubsub, "0.5.0", "ce238708d8c0c98a13e912e1d5ff093fc7958816e3cdffae5763c33a439f7701", [:mix], [{:redix, "~> 0.8", [hex: :redix, repo: "hexpm", optional: false]}], "hexpm"},
+  "redix": {:hex, :redix, "0.9.0", "c631c921354587e054bf1e2a6b7d0120d617352fc42b624b9ca79ea484d0326c", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
Redix 0.9 rolls `redix_pubsub` into the main app, so it can be dropped as a dependency.