### PR TITLE
Fix error pattern for redix disconnection handler

### DIFF
--- a/lib/phoenix_pubsub_redis/redis_server.ex
+++ b/lib/phoenix_pubsub_redis/redis_server.ex
@@ -69,7 +69,8 @@ defmodule Phoenix.PubSub.RedisServer do
     {:noreply, state}
   end
 
-  def handle_info({:redix_pubsub, redix_pid, _reference, :disconnected, %{reason: reason}}, %{redix_pid: redix_pid} = state) do
+  def handle_info({:redix_pubsub, redix_pid, _reference, :disconnected,
+    %{error: %{reason: reason}}}, %{redix_pid: redix_pid} = state) do
     Logger.error "Phoenix.PubSub disconnected from Redis with reason #{inspect reason} (awaiting reconnection)"
     {:noreply, state}
   end


### PR DESCRIPTION
The pattern for the `:disconnected` handler wasn't quite right and caused a crash when it was triggered. This change should fix it.