### PR TITLE
Allow socket opts on ssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,15 @@ config :my_app, MyApp.Endpoint,
 
 Config Options
 
-Option       | Description                                                            | Default        |
-:----------- | :--------------------------------------------------------------------- | :------------- |
-`:name`      | The required name to register the PubSub processes, ie: `MyApp.PubSub` |                |
-`:node_name` | The required name of the node, ie: `System.get_env("NODE")`            |                |
-`:url`       | The redis-server URL, ie: `redis://username:password@host:port`        |                |
-`:host`      | The redis-server host IP                                               | `"127.0.0.1"`  |
-`:port`      | The redis-server port                                                  | `6379`         |
-`:password`  | The redis-server password                                              | `""`           |
+Option         | Description                                                            | Default        |
+:--------------| :--------------------------------------------------------------------- | :------------- |
+`:name`        | The required name to register the PubSub processes, ie: `MyApp.PubSub` |                |
+`:node_name`   | The required name of the node, ie: `System.get_env("NODE")`            |                |
+`:url`         | The redis-server URL, ie: `redis://username:password@host:port`        |                |
+`:host`        | The redis-server host IP                                               | `"127.0.0.1"`  |
+`:port`        | The redis-server port                                                  | `6379`         |
+`:password`    | The redis-server password                                              | `""`           |
+`:socket_opts` | The redis-server network layer options                                 | `[]`           |
 
 And also add `:phoenix_pubsub_redis` to your list of applications:
 

--- a/lib/phoenix_pubsub_redis/redis.ex
+++ b/lib/phoenix_pubsub_redis/redis.ex
@@ -32,7 +32,7 @@ defmodule Phoenix.PubSub.Redis do
 
   @behaviour Phoenix.PubSub.Adapter
   @redis_pool_size 5
-  @redis_opts [:host, :port, :password, :database, :ssl]
+  @redis_opts [:host, :port, :password, :database, :ssl, :socket_opts]
   @defaults [host: "127.0.0.1", port: 6379]
 
   ## Adapter callbacks

--- a/lib/phoenix_pubsub_redis/redis.ex
+++ b/lib/phoenix_pubsub_redis/redis.ex
@@ -25,6 +25,7 @@ defmodule Phoenix.PubSub.Redis do
     * `:password` - The redis-server password, defaults `""`
     * `:ssl` - The redis-server ssl option, defaults `false`
     * `:redis_pool_size` - The size of the redis connection pool. Defaults `5`
+    * `:socket_opts` - List of options that are passed to the network layer when connecting to the Redis server. Default `[]`
 
   """
 


### PR DESCRIPTION
## Motivation

We use Redis Secure connections with self-signed certificates, because of that we need to customize the `socket_opts` that redix uses to establish the connection. But currently the `phoenix_pubsub_redis` doesn't allow to passing this options down to redix.

## Proposed solution

Allow the `socket_opts` to be passed.