### PR TITLE
upgrade to redix 0.10.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule PhoenixPubsubRedis.Mixfile do
   defp deps do
     [
       phoenix_pubsub(),
-      {:redix, "~> 0.9.0"},
+      {:redix, "~> 0.10.0"},
       {:ex_doc, ">= 0.0.0", only: :docs},
       {:poolboy, "~> 1.5.1 or ~> 1.6"}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -7,5 +7,6 @@
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.1", "c90796ecee0289dbb5ad16d3ad06f957b0cd1199769641c961cfe0b97db190e0", [:mix], [], "hexpm"},
   "phoenix_pubsub": {:git, "https://github.com/phoenixframework/phoenix_pubsub.git", "2c9187bee66a861d213d49b6670ebff6677b9810", []},
   "poolboy": {:hex, :poolboy, "1.5.2", "392b007a1693a64540cead79830443abf5762f5d30cf50bc95cb2c1aaafa006b", [:rebar3], [], "hexpm"},
-  "redix": {:hex, :redix, "0.9.2", "a753d5c642e1df21c5444ebb038f1ee3e52c180a63b9d78368f453efcadef311", [:mix], [], "hexpm"},
+  "redix": {:hex, :redix, "0.10.4", "b87c1728e02dd8bad0e8ed2a97c4855d9677dfcefb293800fdb1ca726278ea27", [:mix], [{:castore, "~> 0.1.0", [hex: :castore, repo: "hexpm", optional: true]}, {:telemetry, "~> 0.4.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm"},
+  "telemetry": {:hex, :telemetry, "0.4.1", "ae2718484892448a24470e6aa341bc847c3277bfb8d4e9289f7474d752c09c7f", [:rebar3], [], "hexpm"},
 }


### PR DESCRIPTION
No super breaking changes, `:log` option deprecated, but we weren't using it and everything else is telemetry-related

https://github.com/whatyouhide/redix/blob/master/CHANGELOG.md#v0100