### PR TITLE
Emphasize that node_name must be unique on readme and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Config Options
 Option         | Description                                                            | Default        |
 :--------------| :--------------------------------------------------------------------- | :------------- |
 `:name`        | The required name to register the PubSub processes, ie: `MyApp.PubSub` |                |
-`:node_name`   | The required name of the node, ie: `System.get_env("NODE")`            |                |
+`:node_name`   | The required and unique name of the node, ie: `System.get_env("NODE")` |                |
 `:url`         | The redis-server URL, ie: `redis://username:password@host:port`        |                |
 `:host`        | The redis-server host IP                                               | `"127.0.0.1"`  |
 `:port`        | The redis-server port                                                  | `6379`         |

--- a/lib/phoenix_pubsub_redis/redis.ex
+++ b/lib/phoenix_pubsub_redis/redis.ex
@@ -19,7 +19,7 @@ defmodule Phoenix.PubSub.Redis do
 
     * `:url` - The url to the redis server ie: `redis://username:password@host:port`
     * `:name` - The required name to register the PubSub processes, ie: `MyApp.PubSub`
-    * `:node_name` - The required name of the node, defaults to Erlang --sname flag.
+    * `:node_name` - The required name of the node, defaults to Erlang --sname flag. It must be unique.
     * `:host` - The redis-server host IP, defaults `"127.0.0.1"`
     * `:port` - The redis-server port, defaults `6379`
     * `:password` - The redis-server password, defaults `""`


### PR DESCRIPTION
I decided to open this pull request after I spent a good number of hours trying to debug why my pubsub was not working. The problem was that I was running several pods in kubernetes but they were not configured in an erlang cluster - they all were using the same value for `--name` (I know, I know)

I had read the docs of the redis adapter for phoenix pubsub a few times before I realized what was happening.

Hopefully this change will make it more obvious that `node_name` must be unique and save someone's time in the future.