### PR TITLE
Add sentinel support for 3.x

### DIFF
--- a/lib/phoenix_pubsub_redis/redis.ex
+++ b/lib/phoenix_pubsub_redis/redis.ex
@@ -27,6 +27,7 @@ defmodule Phoenix.PubSub.Redis do
     * `:redis_pool_size` - The size of the redis connection pool. Defaults `5`
     * `:compression_level` - Compression level applied to serialized terms - from `0` (no compression), to `9` (highest). Defaults `0`
     * `:socket_opts` - List of options that are passed to the network layer when connecting to the Redis server. Default `[]`
+    * `:sentinel` - Redix sentinel configuration. Default to `nil`
 
   """
 

--- a/lib/phoenix_pubsub_redis/redis.ex
+++ b/lib/phoenix_pubsub_redis/redis.ex
@@ -34,7 +34,7 @@ defmodule Phoenix.PubSub.Redis do
 
   @behaviour Phoenix.PubSub.Adapter
   @redis_pool_size 5
-  @redis_opts [:host, :port, :password, :database, :ssl, :socket_opts]
+  @redis_opts [:host, :port, :password, :database, :ssl, :socket_opts, :sentinel]
   @defaults [host: "127.0.0.1", port: 6379]
 
   ## Adapter callbacks

--- a/lib/phoenix_pubsub_redis/redis_server.ex
+++ b/lib/phoenix_pubsub_redis/redis_server.ex
@@ -67,6 +67,14 @@ defmodule Phoenix.PubSub.RedisServer do
     {:ok, establish_conn(state)}
   end
 
+  def handle_call(:healthcheck, _from, %{redix_pid: nil} = state) do
+    {:reply, :error, state}
+  end
+
+  def handle_call(:healthcheck, _from, %{redix_pid: pid} = state) when is_pid(pid) do
+    {:reply, :ok, state}
+  end
+
   def handle_info(:establish_conn, state) do
     {:noreply, establish_conn(%{state | reconnect_timer: nil})}
   end

--- a/lib/phoenix_pubsub_redis/redis_server.ex
+++ b/lib/phoenix_pubsub_redis/redis_server.ex
@@ -67,14 +67,6 @@ defmodule Phoenix.PubSub.RedisServer do
     {:ok, establish_conn(state)}
   end
 
-  def handle_call(:healthcheck, _from, %{redix_pid: nil} = state) do
-    {:reply, :error, state}
-  end
-
-  def handle_call(:healthcheck, _from, %{redix_pid: pid} = state) when is_pid(pid) do
-    {:reply, :ok, state}
-  end
-
   def handle_info(:establish_conn, state) do
     {:noreply, establish_conn(%{state | reconnect_timer: nil})}
   end


### PR DESCRIPTION
Hello, I noticed that in our project passing sentinel configuration for Redix was not working. Adding `:sentinel` key to list of accepted opts fixed it. If it's ok with you, I also would like to submit another PR with same fix for 2.x branch.