### PR TITLE
Allow 'rediss' URL scheme to define whether SSL is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Option                  | Description                                           
 `:host`                 | The redis-server host IP                                                  | `"127.0.0.1"`  |
 `:port`                 | The redis-server port                                                     | `6379`         |
 `:password`             | The redis-server password                                                 | `""`           |
+`:ssl`                  | The redis-server SSL flag                                                 | `false`        |
 `:compression_level`    | Compression level applied to serialized terms (`0` - none, `9` - highest) | `0`            |
 `:socket_opts`          | The redis-server network layer options                                    | `[]`           |
 

--- a/lib/phoenix_pubsub_redis/redis.ex
+++ b/lib/phoenix_pubsub_redis/redis.ex
@@ -23,7 +23,7 @@ defmodule Phoenix.PubSub.Redis do
     * `:host` - The redis-server host IP, defaults `"127.0.0.1"`
     * `:port` - The redis-server port, defaults `6379`
     * `:password` - The redis-server password, defaults `""`
-    * `:ssl` - The redis-server ssl option, defaults `false`
+    * `:ssl` - The redis-server ssl option, defaults `false`, unless the URL scheme is `rediss`
     * `:redis_pool_size` - The size of the redis connection pool. Defaults `5`
     * `:compression_level` - Compression level applied to serialized terms - from `0` (no compression), to `9` (highest). Defaults `0`
     * `:socket_opts` - List of options that are passed to the network layer when connecting to the Redis server. Default `[]`
@@ -111,9 +111,12 @@ defmodule Phoenix.PubSub.Redis do
         [username, password] -> [username: username, password: password]
       end
 
+    ssl = info.scheme == "rediss"
+
     opts
     |> Keyword.merge(user_opts)
     |> Keyword.merge(host: info.host, port: info.port || @defaults[:port])
+    |> Keyword.put(:ssl, ssl)
   end
 
   defp validate_node_name!(node_name) do


### PR DESCRIPTION
We use the `REDIS_URL` env var on Heroku to define our Redis URL. When SSL is enabled this is indicated by the `rediss` scheme in the URL.

As it stands, `phoenix_pubsub_redis` ignores this, and forces us to set `ssl: true` to use SSL for the connection.

This change allows the URL scheme to define whether SSL is enabled, removing the need to keep the `:ssl` setting inline with the URL scheme.