### PR TITLE
Don't use defaults when `:sentinel` is set

### DIFF
--- a/lib/phoenix_pubsub_redis/redis.ex
+++ b/lib/phoenix_pubsub_redis/redis.ex
@@ -68,7 +68,14 @@ defmodule Phoenix.PubSub.Redis do
     compression_level = Keyword.get(opts, :compression_level, 0)
 
     opts = handle_url_opts(opts)
-    opts = Keyword.merge(@defaults, opts)
+
+    opts =
+      if is_nil(opts[:sentinel]) do
+        Keyword.merge(@defaults, opts)
+      else
+        opts
+      end
+
     redis_opts = Keyword.take(opts, @redis_opts)
 
     node_name = opts[:node_name] || node()


### PR DESCRIPTION
redix doesn't allow to connect to sentinel when host or password is set:
https://github.com/whatyouhide/redix/blob/44638994386a9372c2a270f8faba66d57c58f758/lib/redix/start_options.ex#L83-L85