### PR TITLE
Delegate redis connection build to redix

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,22 +19,20 @@ children = [
   # ...,
   {Phoenix.PubSub,
    adapter: Phoenix.PubSub.Redis,
-   host: "192.168.1.100",
+   redis_opts: [host: "192.168.1.100"],
    node_name: System.get_env("NODE")}
 ```
 
 Config Options
 
-Option                  | Description                                                               | Default        |
-:-----------------------| :------------------------------------------------------------------------ | :------------- |
-`:name`                 | The required name to register the PubSub processes, ie: `MyApp.PubSub`    |                |
-`:node_name`            | The required and unique name of the node, ie: `System.get_env("NODE")`    |                |
-`:url`                  | The redis-server URL, ie: `redis://username:password@host:port`           |                |
-`:host`                 | The redis-server host IP                                                  | `"127.0.0.1"`  |
-`:port`                 | The redis-server port                                                     | `6379`         |
-`:password`             | The redis-server password                                                 | `""`           |
-`:compression_level`    | Compression level applied to serialized terms (`0` - none, `9` - highest) | `0`            |
-`:socket_opts`          | The redis-server network layer options                                    | `[]`           |
+Option                  | Description                                                                                | Default        |
+:-----------------------| :----------------------------------------------------------------------------------------- | :------------- |
+`:name`                 | The required name to register the PubSub processes, ie: `MyApp.PubSub`                     |                |
+`:node_name`            | The required and unique name of the node, ie: `System.get_env("NODE")`                     |                |
+`:url`                  | The redis-server URL, ie: `redis://username:password@host:port`                            |                |
+`:compression_level`    | Compression level applied to serialized terms (`0` - none, `9` - highest)                  | `0`            |
+`:redis_pool_size`      | The size of the redis connection pool.                                                     | `5`            |
+`:redis_opts`           | Redis connection opts. See: https://hexdocs.pm/redix/Redix.html#start_link/1-redis-options |                |
 
 And also add `:phoenix_pubsub_redis` to your list of applications:
 

--- a/lib/phoenix_pubsub_redis/redis.ex
+++ b/lib/phoenix_pubsub_redis/redis.ex
@@ -6,7 +6,7 @@ defmodule Phoenix.PubSub.Redis do
 
       {Phoenix.PubSub,
        adapter: Phoenix.PubSub.Redis,
-       host: "192.168.1.100",
+       redis_opts: [host: "192.168.1.100"],
        node_name: System.get_env("NODE")}
 
   You will also need to add `:phoenix_pubsub_redis` to your deps:
@@ -20,14 +20,9 @@ defmodule Phoenix.PubSub.Redis do
     * `:url` - The url to the redis server ie: `redis://username:password@host:port`
     * `:name` - The required name to register the PubSub processes, ie: `MyApp.PubSub`
     * `:node_name` - The required name of the node, defaults to Erlang --sname flag. It must be unique.
-    * `:host` - The redis-server host IP, defaults `"127.0.0.1"`
-    * `:port` - The redis-server port, defaults `6379`
-    * `:password` - The redis-server password, defaults `""`
-    * `:ssl` - The redis-server ssl option, defaults `false`
     * `:redis_pool_size` - The size of the redis connection pool. Defaults `5`
     * `:compression_level` - Compression level applied to serialized terms - from `0` (no compression), to `9` (highest). Defaults `0`
-    * `:socket_opts` - List of options that are passed to the network layer when connecting to the Redis server. Default `[]`
-    * `:sentinel` - Redix sentinel configuration. Default to `nil`
+    * `:redis_opts` - Redis connection opts. See: https://hexdocs.pm/redix/Redix.html#start_link/1-redis-options
 
   """
 

--- a/lib/phoenix_pubsub_redis/redis.ex
+++ b/lib/phoenix_pubsub_redis/redis.ex
@@ -35,7 +35,7 @@ defmodule Phoenix.PubSub.Redis do
 
   @behaviour Phoenix.PubSub.Adapter
   @redis_pool_size 5
-  @redis_opts [:host, :port, :password, :database, :ssl, :socket_opts, :sentinel]
+  @redis_opts [:host, :port, :password, :database, :ssl, :socket_opts, :sentinel, :username]
   @defaults [host: "127.0.0.1", port: 6379]
 
   ## Adapter callbacks

--- a/lib/phoenix_pubsub_redis/redis.ex
+++ b/lib/phoenix_pubsub_redis/redis.ex
@@ -110,10 +110,10 @@ defmodule Phoenix.PubSub.Redis do
   end
 
   defp redis_opts(opts) do
-    # TODO: update docs
-    # TODO: parse uri https://github.com/whatyouhide/redix/blob/v1.1.5/lib/redix/uri.ex#L5
-    opts
-    |> Keyword.take(@redis_opts ++ [:url])
+    user_opts = if opts[:url], do: Redix.URI.opts_from_uri(opts[:url]), else: []
+
+    user_opts
+    |> Keyword.merge(Keyword.take(opts, @redis_opts))
     |> Keyword.merge(Keyword.get(opts, :redis_opts, []))
   end
 

--- a/test/phoenix_pubsub_redis_test.exs
+++ b/test/phoenix_pubsub_redis_test.exs
@@ -1,2 +1,103 @@
-Application.put_env(:phoenix_pubsub, :test_adapter, {Phoenix.PubSub.Redis, node_name: :SAMPLE, compression_level: 1})
-Code.require_file "#{Mix.Project.deps_paths[:phoenix_pubsub]}/test/shared/pubsub_test.exs"
+Application.put_env(
+  :phoenix_pubsub,
+  :test_adapter,
+  {Phoenix.PubSub.Redis, node_name: :SAMPLE, compression_level: 1}
+)
+
+Code.require_file("#{Mix.Project.deps_paths()[:phoenix_pubsub]}/test/shared/pubsub_test.exs")
+
+defmodule Phoenix.PubSub.RedisTest do
+  use ExUnit.Case, async: true
+
+  alias Phoenix.PubSub.Redis
+
+  describe "build_opts/1" do
+    test "build opts with defaults" do
+      assert Map.new(Redis.build_opts(name: Phoenix.TestName, adapter_name: :adapter_name)) ==
+               Map.new(
+                 node_name: node(),
+                 name: Phoenix.TestName,
+                 adapter_name: :adapter_name,
+                 redis_pool_size: 5,
+                 redis_opts: [],
+                 compression_level: 0
+               )
+    end
+
+    test "fill redis opts as-is" do
+      assert Map.new(
+               Redis.build_opts(
+                 name: Phoenix.TestName,
+                 adapter_name: :adapter_name,
+                 host: "example.com",
+                 port: 5000,
+                 password: "password",
+                 database: "database",
+                 ssl: true,
+                 socket_opts: [verify: :no_verify],
+                 sentinel: [
+                   sentinels: [
+                     "redis://sent1.example.com:26379",
+                     "redis://sent2.example.com:26379"
+                   ],
+                   group: "main"
+                 ],
+                 url: "redis://localhost:6379/3"
+               )
+             ) ==
+               Map.new(
+                 node_name: node(),
+                 name: Phoenix.TestName,
+                 adapter_name: :adapter_name,
+                 redis_pool_size: 5,
+                 compression_level: 0,
+                 redis_opts: [
+                   host: "example.com",
+                   port: 5000,
+                   password: "password",
+                   database: "database",
+                   ssl: true,
+                   socket_opts: [verify: :no_verify],
+                   sentinel: [
+                     sentinels: [
+                       "redis://sent1.example.com:26379",
+                       "redis://sent2.example.com:26379"
+                     ],
+                     group: "main"
+                   ],
+                   url: "redis://localhost:6379/3"
+                 ]
+               )
+    end
+
+    test "redis_opts will be merged redis opts from root" do
+      assert Map.new(
+               Redis.build_opts(
+                 name: Phoenix.TestName,
+                 adapter_name: :adapter_name,
+                 host: "example.com",
+                 port: 5000,
+                 password: "another",
+                 database: "another",
+                 redis_opts: [
+                   password: "password",
+                   database: "database"
+                 ]
+               )
+             ) ==
+               Map.new(
+                 node_name: node(),
+                 name: Phoenix.TestName,
+                 adapter_name: :adapter_name,
+                 redis_pool_size: 5,
+                 compression_level: 0,
+                 redis_opts: [
+                   host: "example.com",
+                   port: 5000,
+                   password: "password",
+                   database: "database"
+                 ]
+               )
+    end
+  end
+end

--- a/test/phoenix_pubsub_redis_test.exs
+++ b/test/phoenix_pubsub_redis_test.exs
@@ -32,7 +32,7 @@ defmodule Phoenix.PubSub.RedisTest do
                  host: "example.com",
                  port: 5000,
                  password: "password",
-                 database: "database",
+                 database: 1,
                  ssl: true,
                  socket_opts: [verify: :no_verify],
                  sentinel: [
@@ -41,8 +41,7 @@ defmodule Phoenix.PubSub.RedisTest do
                      "redis://sent2.example.com:26379"
                    ],
                    group: "main"
-                 ],
-                 url: "redis://localhost:6379/3"
+                 ]
                )
              ) ==
                Map.new(
@@ -55,7 +54,7 @@ defmodule Phoenix.PubSub.RedisTest do
                    host: "example.com",
                    port: 5000,
                    password: "password",
-                   database: "database",
+                   database: 1,
                    ssl: true,
                    socket_opts: [verify: :no_verify],
                    sentinel: [
@@ -64,8 +63,7 @@ defmodule Phoenix.PubSub.RedisTest do
                        "redis://sent2.example.com:26379"
                      ],
                      group: "main"
-                   ],
-                   url: "redis://localhost:6379/3"
+                   ]
                  ]
                )
     end
@@ -78,10 +76,10 @@ defmodule Phoenix.PubSub.RedisTest do
                  host: "example.com",
                  port: 5000,
                  password: "another",
-                 database: "another",
+                 database: 1,
                  redis_opts: [
                    password: "password",
-                   database: "database"
+                   database: 2
                  ]
                )
              ) ==
@@ -95,7 +93,31 @@ defmodule Phoenix.PubSub.RedisTest do
                    host: "example.com",
                    port: 5000,
                    password: "password",
-                   database: "database"
+                   database: 2
+                 ]
+               )
+    end
+
+    test "parse url opts" do
+      assert Map.new(
+               Redis.build_opts(
+                 name: Phoenix.TestName,
+                 adapter_name: :adapter_name,
+                 url: "rediss://username:password@example.com:5000/1"
+               )
+             ) ==
+               Map.new(
+                 node_name: node(),
+                 name: Phoenix.TestName,
+                 adapter_name: :adapter_name,
+                 redis_pool_size: 5,
+                 compression_level: 0,
+                 redis_opts: [
+                   ssl: true,
+                   database: 1,
+                   password: "password",
+                   port: 5000,
+                   host: "example.com"
                  ]
                )
     end


### PR DESCRIPTION
## Motivation

Recently I was setting up `phoenix_pubsub_redis` in out application, and I incurred in a few problems connecting to ElastiCache redis. The most confusing thing was that I was able to connect to redis using `Redix.start_link` normally, but if I used the same opts with `phoenix_pubsub_redis` it would fail. In the end the problem was that the option `username` [is been ignored](https://github.com/phoenixframework/phoenix_pubsub_redis/blob/master/lib/phoenix_pubsub_redis/redis.ex#L38).

Looking in the repository we have a few other open and closed PRs with similar issues.
Updating the code just to add behaviour on the parsing of redis urls or allowing new options that `redix` supports.

- https://github.com/phoenixframework/phoenix_pubsub_redis/pull/38
- https://github.com/phoenixframework/phoenix_pubsub_redis/pull/43
- https://github.com/phoenixframework/phoenix_pubsub_redis/pull/46
- https://github.com/phoenixframework/phoenix_pubsub_redis/pull/58
- https://github.com/phoenixframework/phoenix_pubsub_redis/pull/60

## Proposed Solution

I would like to propose delegating the handle of redis connection opts directly to redis, 

- so we don't have to maintain a version of the url parsing inside of `phoenix_pubsub_redis`