### PR TITLE
Make Redis channel configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ end
 children = [
   # ...,
   {Phoenix.PubSub,
+   name: MyApp.PubSub,
    adapter: Phoenix.PubSub.Redis,
    host: "192.168.1.100",
    node_name: System.get_env("NODE")}
@@ -25,26 +26,17 @@ children = [
 
 Config Options
 
-Option                  | Description                                                               | Default        |
-:-----------------------| :------------------------------------------------------------------------ | :------------- |
-`:name`                 | The required name to register the PubSub processes, ie: `MyApp.PubSub`    |                |
-`:node_name`            | The required and unique name of the node, ie: `System.get_env("NODE")`    |                |
-`:url`                  | The redis-server URL, ie: `redis://username:password@host:port`           |                |
-`:host`                 | The redis-server host IP                                                  | `"127.0.0.1"`  |
-`:port`                 | The redis-server port                                                     | `6379`         |
-`:password`             | The redis-server password                                                 | `""`           |
-`:compression_level`    | Compression level applied to serialized terms (`0` - none, `9` - highest) | `0`            |
-`:socket_opts`          | The redis-server network layer options                                    | `[]`           |
-
-And also add `:phoenix_pubsub_redis` to your list of applications:
-
-```elixir
-# mix.exs
-def application do
-  [mod: {MyApp, []},
-   applications: [..., :phoenix, :phoenix_pubsub_redis]]
-end
-```
+Option                  | Description                                                               | Default           |
+:-----------------------| :------------------------------------------------------------------------ | :---------------- |
+`:name`                 | The required name to register the PubSub processes, ie: `MyApp.PubSub`    |                   |
+`:node_name`            | The required and unique name of the node, ie: `System.get_env("NODE")`    |                   |
+`:url`                  | The redis-server URL, ie: `redis://username:password@host:port`           |                   |
+`:host`                 | The redis-server host IP                                                  | `"127.0.0.1"`     |
+`:port`                 | The redis-server port                                                     | `6379`            |
+`:password`             | The redis-server password                                                 | `""`              |
+`:compression_level`    | Compression level applied to serialized terms (`0` - none, `9` - highest) | `0`               |
+`:socket_opts`          | The redis-server network layer options                                    | `[]`              |
+`:redis_channel`        | The redis pubsub channel, i.e. `myapp:pubsub`                             | Derived from name |
 
 ## License
 

--- a/lib/phoenix_pubsub_redis/redis.ex
+++ b/lib/phoenix_pubsub_redis/redis.ex
@@ -5,6 +5,7 @@ defmodule Phoenix.PubSub.Redis do
   To start it, list it in your supervision tree as:
 
       {Phoenix.PubSub,
+       name: MyApp.PubSub,
        adapter: Phoenix.PubSub.Redis,
        host: "192.168.1.100",
        node_name: System.get_env("NODE")}
@@ -28,6 +29,7 @@ defmodule Phoenix.PubSub.Redis do
     * `:compression_level` - Compression level applied to serialized terms - from `0` (no compression), to `9` (highest). Defaults `0`
     * `:socket_opts` - List of options that are passed to the network layer when connecting to the Redis server. Default `[]`
     * `:sentinel` - Redix sentinel configuration. Default to `nil`
+    * `:redis_channel` - Redis channel to use, derived from the name by default
 
   """
 
@@ -66,6 +68,7 @@ defmodule Phoenix.PubSub.Redis do
     pubsub_name = Keyword.fetch!(opts, :name)
     adapter_name = Keyword.fetch!(opts, :adapter_name)
     compression_level = Keyword.get(opts, :compression_level, 0)
+    redis_channel = Keyword.get(opts, :redis_channel, default_redis_channel(adapter_name))
 
     opts = handle_url_opts(opts)
     opts = Keyword.merge(@defaults, opts)
@@ -77,6 +80,7 @@ defmodule Phoenix.PubSub.Redis do
     :ets.new(adapter_name, [:public, :named_table, read_concurrency: true])
     :ets.insert(adapter_name, {:node_name, node_name})
     :ets.insert(adapter_name, {:compression_level, compression_level})
+    :ets.insert(adapter_name, {:redis_channel, redis_channel})
 
     pool_opts = [
       name: {:local, adapter_name},
@@ -123,4 +127,6 @@ defmodule Phoenix.PubSub.Redis do
 
     :ok
   end
+
+  defp default_redis_channel(adapter_name), do: "phx:#{adapter_name}"
 end

--- a/lib/phoenix_pubsub_redis/redis_server.ex
+++ b/lib/phoenix_pubsub_redis/redis_server.ex
@@ -22,7 +22,7 @@ defmodule Phoenix.PubSub.RedisServer do
   end
 
   defp publish(adapter_name, mode, node_name, topic, message, dispatcher) do
-    namespace = redis_namespace(adapter_name)
+    namespace = redis_channel(adapter_name)
     compression_level = compression_level(adapter_name)
     redis_msg = {@redis_msg_vsn, mode, node_name, topic, message, dispatcher}
     bin_msg = :erlang.term_to_binary(redis_msg, compressed: compression_level)
@@ -125,7 +125,7 @@ defmodule Phoenix.PubSub.RedisServer do
   end
 
   defp establish_success(%{redix_pid: redix_pid, adapter_name: adapter_name} = state) do
-    {:ok, _reference} = Redix.PubSub.subscribe(redix_pid, redis_namespace(adapter_name), self())
+    {:ok, _reference} = Redix.PubSub.subscribe(redix_pid, redis_channel(adapter_name), self())
     state
   end
 
@@ -139,5 +139,7 @@ defmodule Phoenix.PubSub.RedisServer do
     end
   end
 
-  defp redis_namespace(adapter_name), do: "phx:#{adapter_name}"
+  defp redis_channel(adapter_name) do
+    :ets.lookup_element(adapter_name, :redis_channel, 2)
+  end
 end


### PR DESCRIPTION
Here I'm proposing an addition to the configuration options for `Phoenix.PubSub.Redis` to make it possible to specify the Redis channel for pubsub directly.

## Motivation

Currently the Redis channel name is derived from the adapter name, e.g. `"phx:Elixir.MyApp.PubSub.Adapter"`. This is not entirely obvious and could pose a challenge for some applications:

* When using `Phoenix.PubSub` with Redis to communicate between separate Elixir app/umbrella apps, the current design makes it necessary for the registered name for the pubsub process to be the same across all apps. This is a particular challenge in umbrella apps where it might be desirable to have separate pubsub processes per app.
* It is possible to inadvertently change the channel used by modifying the module name defined for `Phoenix.PubSub`. In some situations this could cause unexpected behaviour, especially if the pubsub channel is used in a distributed environment.
* The coupling of the adaptor name to the Redis channel means other systems participating in the channel need to adopt the internal naming of an Elixir app

Personally I ran into this with an umbrella app where we want to have separate pubsub processes per app to avoid coupling.

## Changes

Changes are straight forward, basically just accepting an optional `redis_channel` configuration argument and stashing that in ETS. The implementation defaults to the current channel naming where no channel name is specified, so as to be backward compatible.

