### PR TITLE
Add key_prefix option to change the key named used in redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Option                  | Description                                           
 `:password`             | The redis-server password                                                 | `""`           |
 `:compression_level`    | Compression level applied to serialized terms (`0` - none, `9` - highest) | `0`            |
 `:socket_opts`          | The redis-server network layer options                                    | `[]`           |
+`:key_prefix`           | The key prefix to use for the redis key                                   | `phx`           |
 
 And also add `:phoenix_pubsub_redis` to your list of applications:
 

--- a/lib/phoenix_pubsub_redis/redis.ex
+++ b/lib/phoenix_pubsub_redis/redis.ex
@@ -28,7 +28,7 @@ defmodule Phoenix.PubSub.Redis do
     * `:compression_level` - Compression level applied to serialized terms - from `0` (no compression), to `9` (highest). Defaults `0`
     * `:socket_opts` - List of options that are passed to the network layer when connecting to the Redis server. Default `[]`
     * `:sentinel` - Redix sentinel configuration. Default to `nil`
-    * `:key_prefix` - Key prefix to add to the redis PubSub key, defaults `nil`
+    * `:key_prefix` - Key prefix to add to the redis PubSub key. Defaults `phx`
 
   """
 

--- a/lib/phoenix_pubsub_redis/redis.ex
+++ b/lib/phoenix_pubsub_redis/redis.ex
@@ -28,6 +28,7 @@ defmodule Phoenix.PubSub.Redis do
     * `:compression_level` - Compression level applied to serialized terms - from `0` (no compression), to `9` (highest). Defaults `0`
     * `:socket_opts` - List of options that are passed to the network layer when connecting to the Redis server. Default `[]`
     * `:sentinel` - Redix sentinel configuration. Default to `nil`
+    * `:key_prefix` - Key prefix to add to the redis PubSub key, defaults `nil`
 
   """
 
@@ -66,6 +67,7 @@ defmodule Phoenix.PubSub.Redis do
     pubsub_name = Keyword.fetch!(opts, :name)
     adapter_name = Keyword.fetch!(opts, :adapter_name)
     compression_level = Keyword.get(opts, :compression_level, 0)
+    key_prefix = Keyword.get(opts, :key_prefix, nil)
 
     opts = handle_url_opts(opts)
     opts = Keyword.merge(@defaults, opts)
@@ -74,8 +76,10 @@ defmodule Phoenix.PubSub.Redis do
     node_name = opts[:node_name] || node()
     validate_node_name!(node_name)
 
+
     :ets.new(adapter_name, [:public, :named_table, read_concurrency: true])
     :ets.insert(adapter_name, {:node_name, node_name})
+    :ets.insert(adapter_name, {:key_prefix, key_prefix})
     :ets.insert(adapter_name, {:compression_level, compression_level})
 
     pool_opts = [


### PR DESCRIPTION
I had a need to share the redis server across a couple of different applications, so I added an option to change the key prefix used with redis so they dont receive the same pubsub messages.