### PR TITLE
add `username` as a redis-server option

### DIFF
--- a/lib/phoenix_pubsub_redis/redis.ex
+++ b/lib/phoenix_pubsub_redis/redis.ex
@@ -22,6 +22,7 @@ defmodule Phoenix.PubSub.Redis do
     * `:node_name` - The required name of the node, defaults to Erlang --sname flag. It must be unique.
     * `:host` - The redis-server host IP, defaults `"127.0.0.1"`
     * `:port` - The redis-server port, defaults `6379`
+    * `:username` - The redis-server username
     * `:password` - The redis-server password, defaults `""`
     * `:ssl` - The redis-server ssl option, defaults `false`
     * `:redis_pool_size` - The size of the redis connection pool. Defaults `5`
@@ -35,7 +36,7 @@ defmodule Phoenix.PubSub.Redis do
 
   @behaviour Phoenix.PubSub.Adapter
   @redis_pool_size 5
-  @redis_opts [:host, :port, :password, :database, :ssl, :socket_opts, :sentinel]
+  @redis_opts [:host, :port, :username, :password, :database, :ssl, :socket_opts, :sentinel]
   @defaults [host: "127.0.0.1", port: 6379]
 
   ## Adapter callbacks


### PR DESCRIPTION
At the moment it is only possible to specify a username to authenticate to the redis server as part of the `url` option.
Unfortunately, due to the [`Keyword.take(opts, @redis_opts)` at line 72](https://github.com/phoenixframework/phoenix_pubsub_redis/blob/028cd1689c21969a860d934fe6aa5b24fa46e2be/lib/phoenix_pubsub_redis/redis.ex#L72) the username taken from the url is actually discarded, and the default one is always used instead.

In this PR I enabled the `username` as an option, both taken from the `url` as well as specified as a separate option.