### PR TITLE
Allow Redis URL to just have a password and no username

### DIFF
--- a/lib/phoenix_pubsub_redis/redis.ex
+++ b/lib/phoenix_pubsub_redis/redis.ex
@@ -108,6 +108,7 @@ defmodule Phoenix.PubSub.Redis do
       case String.split(info.userinfo || "", ":") do
         [""] -> []
         [username] -> [username: username]
+        ["", password] -> [password: password]
         [username, password] -> [username: username, password: password]
       end
 


### PR DESCRIPTION
I have run into an issue where my Redis server has a password but no username.
As this is a managed Redis instance over which I don't have any control, I'm not able to change this setup or set a username.

The issue is that in that case the Redis connection is still created with username being an empty String and the connection to the server fails.

This small change fixes this use case by only creating a connection with a password.
